### PR TITLE
config: add merge config for tidb-community-bots/ti-community-bot

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -22,6 +22,7 @@ ti-community-merge:
       - tidb-community-bots/ti-community-prow
       - tidb-community-bots/configs
       - tidb-community-bots/ti-challenge-bot
+      - tidb-community-bots/ti-community-bot
       - tikv/pd
       - pingcap/tidb-dashboard
       - pingcap/tidb-operator


### PR DESCRIPTION
No response when we use `/merge` command on  tidb-community-bots/ti-community-bot