### PR TITLE
fix: log the error

### DIFF
--- a/cmd/merge/main.go
+++ b/cmd/merge/main.go
@@ -27,10 +27,9 @@ func (fm orgFlagMap) String() string {
 	var parts []string
 	for key, value := range fm {
 		if value == "" {
-			parts = append(parts, key)
-		} else {
-			parts = append(parts, key+"="+value)
+			continue
 		}
+		parts = append(parts, key+"="+value)
 	}
 	return strings.Join(parts, ",")
 }
@@ -74,17 +73,20 @@ func main() {
 		Orgs: cfg,
 	}
 	out, err := yaml.Marshal(pc)
+	if err != nil {
+		logrus.Fatalf("Failed to marshal orgs: %v", err)
+	}
 	fmt.Println(string(out))
 }
 
 func unmarshal(path string) (*org.Config, error) {
 	buf, err := ioutil.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("read %s: %v", path, err)
+		return nil, fmt.Errorf("read: %v", err)
 	}
 	var cfg org.Config
 	if err := yaml.Unmarshal(buf, &cfg); err != nil {
-		return nil, fmt.Errorf("unmarshal %s: %v", path, err)
+		return nil, fmt.Errorf("unmarshal: %v", err)
 	}
 	return &cfg, nil
 }


### PR DESCRIPTION
Drop path as this is trivially determined from the call signature. It is also already included in the returned error on L97.
https://github.com/tidb-community-bots/configs/blob/c83fcb3527d6c0ec44fc3f5497620d74c2b5722d/cmd/merge/main.go#L97